### PR TITLE
Update android dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'biz.cunning.cunning_document_scanner'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -47,6 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.websitebeaver:documentscanner:1.0.5'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.websitebeaver:documentscanner:1.3.4'
+//    implementation 'androidx.appcompat:appcompat:1.6.1'
 }

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -64,7 +64,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                 when (resultCode) {
                     Activity.RESULT_OK -> {
                         // check for errors
-                        val error = data?.extras?.get("error") as String?
+                        val error = data?.extras?.getString("error")
                         if (error != null) {
                             throw Exception("error - $error")
                         }
@@ -74,7 +74,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                             data?.getStringArrayListExtra("croppedImageResults")?.toList()
                                 ?: throw Exception("No cropped images returned")
 
-                        // return an array of file paths
+                        // return a list of file paths
                         // removing file uri prefix as Flutter file will have problems with it
                         val successResponse = croppedImageResults.map {
                             it.removePrefix("file://")
@@ -105,7 +105,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
     /**
      * create intent to launch document scanner and set custom options
      */
-    fun createDocumentScanIntent(): Intent {
+    private fun createDocumentScanIntent(): Intent {
         val documentScanIntent = Intent(activity, DocumentScannerActivity::class.java)
         documentScanIntent.putExtra(
             DocumentScannerExtra.EXTRA_LET_USER_ADJUST_CROP,
@@ -123,7 +123,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
     /**
      * add document scanner result handler and launch the document scanner
      */
-    fun startScan() {
+    private fun startScan() {
         val intent = createDocumentScanIntent()
         try {
             ActivityCompat.startActivityForResult(

--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -5,10 +5,7 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.core.app.ActivityCompat
 import com.websitebeaver.documentscanner.DocumentScannerActivity
-import com.websitebeaver.documentscanner.constants.DefaultSetting
 import com.websitebeaver.documentscanner.constants.DocumentScannerExtra
-import com.websitebeaver.documentscanner.constants.ResponseType
-import com.websitebeaver.documentscanner.utils.ImageUtil
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -17,7 +14,6 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
-import java.io.File
 
 /** CunningDocumentScannerPlugin */
 class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
@@ -25,7 +21,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
     private var binding: ActivityPluginBinding? = null
     private var pendingResult: Result? = null
     private lateinit var activity: Activity
-    private var responseType: String? = DefaultSetting.RESPONSE_TYPE
     private val START_DOCUMENT_ACTIVITY: Int = 0x362738
 
     /// The MethodChannel that will the communication between Flutter and native Android
@@ -66,17 +61,6 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                 if (requestCode != START_DOCUMENT_ACTIVITY) {
                     return@ActivityResultListener false
                 }
-                // make sure responseType is valid
-                if (!arrayOf(
-                        ResponseType.BASE64,
-                        ResponseType.IMAGE_FILE_PATH
-                    ).contains(responseType)
-                ) {
-                    throw Exception(
-                        "responseType must be either ${ResponseType.BASE64} " +
-                                "or ${ResponseType.IMAGE_FILE_PATH}"
-                    )
-                }
                 when (resultCode) {
                     Activity.RESULT_OK -> {
                         // check for errors
@@ -86,32 +70,15 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                         }
 
                         // get an array with scanned document file paths
-                        val croppedImageResults: ArrayList<String> =
-                            data?.getStringArrayListExtra(
-                                "croppedImageResults"
-                            ) ?: throw Exception("No cropped images returned")
+                        val croppedImageResults =
+                            data?.getStringArrayListExtra("croppedImageResults")?.toList()
+                                ?: throw Exception("No cropped images returned")
 
-                        // if responseType is imageFilePath return an array of file paths
-                        var successResponse: ArrayList<String> = croppedImageResults
-
-                        // if responseType is base64 return an array of base64 images
-                        if (responseType == ResponseType.BASE64) {
-                            val base64CroppedImages =
-                                croppedImageResults.map { croppedImagePath ->
-                                    // read cropped image from file path, and convert to base 64
-                                    val base64Image = ImageUtil().readImageAndConvertToBase64(
-                                        croppedImagePath
-                                    )
-
-                                    // delete cropped image from android device to avoid
-                                    // accumulating photos
-                                    File(croppedImagePath).delete()
-
-                                    base64Image
-                                }
-
-                            successResponse = base64CroppedImages as ArrayList<String>
-                        }
+                        // return an array of file paths
+                        // removing file uri prefix as Flutter file will have problems with it
+                        val successResponse = croppedImageResults.map {
+                            it.removePrefix("file://")
+                        }.toList()
 
                         // trigger the success event handler with an array of cropped images
                         this.pendingResult?.success(successResponse)

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+    <string>Access to camera is required for scanning documents</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
This updates gradle and the dependency on `WebsiteBeaver/android-document-scanner` fixing a bug when cancelling selection of multiple images (#14).

It also removes unnecessary checks for response type as `DocumentScannerActivity` does not return other than `IMAGE_FILE_PATH`.