### PR TITLE
Add namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'biz.cunning.cunning_document_scanner'
+    
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
This small PR fixes the `Could not create an instance of type com.android.build.api.variant.impl.ApplicationVariantImpl` error when building with a recent version of Gradle (8.0.0+).
I hope this can be merged and published quickly as it is very annoying.
The package is great nevertheless!