### PR TITLE
Fix reply already submitted

### DIFF
--- a/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
+++ b/android/src/main/kotlin/biz/cunning/cunning_document_scanner/CunningDocumentScannerPlugin.kt
@@ -73,6 +73,7 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                 if (requestCode != START_DOCUMENT_ACTIVITY && requestCode != START_DOCUMENT_FB_ACTIVITY) {
                     return@ActivityResultListener false
                 }
+                var handled = false
                 if (requestCode == START_DOCUMENT_ACTIVITY) {
                     when (resultCode) {
                         Activity.RESULT_OK -> {
@@ -80,29 +81,26 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                             val error = data?.extras?.getString("error")
                             if (error != null) {
                                 pendingResult?.error("ERROR", "error - $error", null)
-                                return@ActivityResultListener true
+                            } else {
+                                // get an array with scanned document file paths
+                                val scanningResult: GmsDocumentScanningResult =
+                                    data?.extras?.getParcelable("extra_scanning_result")
+                                        ?: return@ActivityResultListener false
+
+                                val successResponse = scanningResult.pages?.map {
+                                    it.imageUri.toString().removePrefix("file://")
+                                }?.toList()
+                                // trigger the success event handler with an array of cropped images
+                                pendingResult?.success(successResponse)
                             }
-
-                            // get an array with scanned document file paths
-                            val scanningResult: GmsDocumentScanningResult =
-                                data?.extras?.getParcelable<GmsDocumentScanningResult>("extra_scanning_result")
-                                    ?: return@ActivityResultListener false
-
-                            val successResponse = scanningResult.pages?.map {
-                                it.imageUri.toString().removePrefix("file://")
-                            }?.toList()
-
-                            // trigger the success event handler with an array of cropped images
-                            pendingResult?.success(successResponse)
-                            return@ActivityResultListener true
+                            handled = true
                         }
 
                         Activity.RESULT_CANCELED -> {
                             // user closed camera
                             pendingResult?.success(emptyList<String>())
-                            return@ActivityResultListener true
+                            handled = true
                         }
-                        else -> return@ActivityResultListener false
                     }
                 } else {
                     when (resultCode) {
@@ -111,36 +109,39 @@ class CunningDocumentScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                             val error = data?.extras?.getString("error")
                             if (error != null) {
                                 pendingResult?.error("ERROR", "error - $error", null)
-                                return@ActivityResultListener true
+                            } else {
+                                // get an array with scanned document file paths
+                                val croppedImageResults =
+                                    data?.getStringArrayListExtra("croppedImageResults")?.toList()
+                                        ?: let {
+                                            pendingResult?.error("ERROR", "No cropped images returned", null)
+                                            return@ActivityResultListener true
+                                        }
+
+                                // return a list of file paths
+                                // removing file uri prefix as Flutter file will have problems with it
+                                val successResponse = croppedImageResults.map {
+                                    it.removePrefix("file://")
+                                }.toList()
+                                // trigger the success event handler with an array of cropped images
+                                pendingResult?.success(successResponse)
                             }
-
-                            // get an array with scanned document file paths
-                            val croppedImageResults =
-                                data?.getStringArrayListExtra("croppedImageResults")?.toList()
-                                    ?: let {
-                                        pendingResult?.error("ERROR", "No cropped images returned", null)
-                                        return@ActivityResultListener true
-                                    }
-
-                            // return a list of file paths
-                            // removing file uri prefix as Flutter file will have problems with it
-                            val successResponse = croppedImageResults.map {
-                                it.removePrefix("file://")
-                            }.toList()
-
-                            // trigger the success event handler with an array of cropped images
-                            pendingResult?.success(successResponse)
-                            return@ActivityResultListener true
+                            handled = true
                         }
 
                         Activity.RESULT_CANCELED -> {
                             // user closed camera
                             pendingResult?.success(emptyList<String>())
-                            return@ActivityResultListener true
+                            handled = true
                         }
-                        else -> return@ActivityResultListener false
                     }
                 }
+
+                if (handled) {
+                    // Clear the pending result to avoid reuse
+                    pendingResult = null
+                }
+                return@ActivityResultListener handled
             }
         } else {
             binding.removeActivityResultListener(this.delegate!!)


### PR DESCRIPTION
This fixes `IllegalStateException: Reply already submitted`, the crash occurs often on Android.

```
Fatal Exception: java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=3548984, result=0, data=null} to activity {com.app.this/com.app.this.MainActivity}: java.lang.IllegalStateException: Reply already submitted
       at android.app.ActivityThread.deliverResults(ActivityThread.java:5555)
       at android.app.ActivityThread.handleSendResult(ActivityThread.java:5596)
       at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2326)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:246)
       at android.app.ActivityThread.main(ActivityThread.java:8570)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)

Caused by java.lang.IllegalStateException: Reply already submitted
       at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:431)
       at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:272)
       at biz.cunning.cunning_document_scanner.CunningDocumentScannerPlugin.addActivityResultListener$lambda$3(CunningDocumentScannerPlugin.kt:102)
       at io.flutter.embedding.engine.FlutterEngineConnectionRegistry$FlutterEngineActivityPluginBinding.onActivityResult(FlutterEngineConnectionRegistry.java:774)
       at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.onActivityResult(FlutterEngineConnectionRegistry.java:422)
       at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onActivityResult(FlutterActivityAndFragmentDelegate.java:857)
       at io.flutter.embedding.android.FlutterActivity.onActivityResult(FlutterActivity.java:884)
       at android.app.Activity.dispatchActivityResult(Activity.java:8541)
       at android.app.ActivityThread.deliverResults(ActivityThread.java:5548)
       at android.app.ActivityThread.handleSendResult(ActivityThread.java:5596)
       at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2326)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:246)
       at android.app.ActivityThread.main(ActivityThread.java:8570)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```