### PR TITLE
Support different output formats on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0
+* Allow users to configure the image output type on iOS (PNG or JPEG).
+
 ## 1.2.3
 * Fix iOS crash where Documentscanner is not available
 

--- a/README.md
+++ b/README.md
@@ -86,18 +86,32 @@ platform :ios, '13.0'
 
 The easiest way to get a list of images is:
 
-```
-    final imagesPath = await CunningDocumentScanner.getPictures()
+```dart
+   final imagesPath = await CunningDocumentScanner.getPictures();
 ```
 ### Android Specific
 
 There are some features in Android that allow you to adjust the scanner that will be ignored in iOS:
 
-```
-    final imagesPath = await CunningDocumentScanner.getPictures(
+```dart
+   final imagesPath = await CunningDocumentScanner.getPictures(
       noOfPages: 1, // Limit the number of pages to 1
       isGalleryImportAllowed, // Allow the user to also pick an image from his gallery
-   )
+   );
+```
+
+### iOS Specific
+
+On iOS it is possible to configure which image format should be used to save of the document scans. Available options are PNG (default) or JPEG. In certain situations the JPEG format could drastically reduce the file size of the final scan. If you choose to use JPEG you can also specify a compression quality, where 0.0 is highest compression (lowest quality) and 1.0 (default) is the lowest compression (highest quality). Example usage is:
+
+```dart
+   // Returns images in JPEG format with a compression quality of 50%. 
+   final imagesPath = await CunningDocumentScanner.getPictures(
+      iosScannerOptions: IosScannerOptions(
+         imageFormat: IosImageFormat.jpg,
+         jpgCompressionQuality: 0.5,
+      ),
+   );
 ```
 
 ## Installation

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   cunning_document_scanner: 7cb9bd173f7cc7b11696dde98d01492187fc3a67
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
-  permission_handler_apple: 036b856153a2b1f61f21030ff725f3e6fece2b78
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
 
 PODFILE CHECKSUM: e78c989774f3b5b54daf69ce13097109fe4b0da3
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -121,7 +121,6 @@
 				1A75B21102973CE41A6E8E7B /* Pods-Runner.release.xcconfig */,
 				554ACEF25A741CCBB5AC6F5D /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -140,6 +139,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				7C0BF88075F6ADB364285AE1 /* [CP] Embed Pods Frameworks */,
+				DE539EF0689856B854BD2C91 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -156,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -267,6 +267,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		DE539EF0689856B854BD2C91 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -488,7 +505,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = F8R24LCAZ8;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,12 @@ class _MyAppState extends State<MyApp> {
   void onPressed() async {
     List<String> pictures;
     try {
-      pictures = await CunningDocumentScanner.getPictures() ?? [];
+      pictures = await CunningDocumentScanner.getPictures(
+              iosScannerOptions: IosScannerOptions(
+            imageFormat: IosImageFormat.jpg,
+            jpgCompressionQuality: 0.5,
+          )) ??
+          [];
       if (!mounted) return;
       setState(() {
         _pictures = pictures;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -357,5 +357,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/ios/Classes/CunningScannerOptions.swift
+++ b/ios/Classes/CunningScannerOptions.swift
@@ -1,0 +1,51 @@
+//
+//  ScannerOptions.swift
+//  cunning_document_scanner
+//
+//  Created by Maurits van Beusekom on 15/10/2024.
+//
+
+import Foundation
+
+enum CunningScannerImageFormat: String {
+    case jpg
+    case png
+}
+
+struct CunningScannerOptions {
+    let imageFormat: CunningScannerImageFormat
+    let jpgCompressionQuality: Double
+    
+    init() {
+        self.imageFormat = CunningScannerImageFormat.png
+        self.jpgCompressionQuality = 1.0
+    }
+    
+    init(imageFormat: CunningScannerImageFormat) {
+        self.imageFormat = imageFormat
+        self.jpgCompressionQuality = 1.0
+    }
+    
+    init(imageFormat: CunningScannerImageFormat, jpgCompressionQuality: Double) {
+        self.imageFormat = imageFormat
+        self.jpgCompressionQuality = jpgCompressionQuality
+    }
+    
+    static func fromArguments(args: Any?) -> CunningScannerOptions {
+        if (args == nil) {
+            return CunningScannerOptions()
+        }
+        
+        let arguments = args as? Dictionary<String, Any>
+    
+        if arguments == nil || arguments!.keys.contains("iosScannerOptions") == false {
+            return CunningScannerOptions()
+        }
+        
+        let scannerOptionsDict = arguments!["iosScannerOptions"] as! Dictionary<String, Any>
+        let imageFormat: String = (scannerOptionsDict["imageFormat"] as? String) ?? "png"
+        let jpgCompressionQuality: Double = (scannerOptionsDict["jpgCompressionQuality"] as? Double) ?? 1.0
+            
+        return CunningScannerOptions(imageFormat: CunningScannerImageFormat(rawValue: imageFormat) ?? CunningScannerImageFormat.png, jpgCompressionQuality: jpgCompressionQuality)
+    }
+}

--- a/ios/Classes/SwiftCunningDocumentScannerPlugin.swift
+++ b/ios/Classes/SwiftCunningDocumentScannerPlugin.swift
@@ -5,8 +5,9 @@ import VisionKit
 
 @available(iOS 13.0, *)
 public class SwiftCunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocumentCameraViewControllerDelegate {
-   var resultChannel: FlutterResult?
-   var presentingController: VNDocumentCameraViewController?
+  var resultChannel: FlutterResult?
+  var presentingController: VNDocumentCameraViewController?
+  var scannerOptions: CunningScannerOptions = CunningScannerOptions()
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "cunning_document_scanner", binaryMessenger: registrar.messenger())
@@ -16,6 +17,7 @@ public class SwiftCunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocum
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     if call.method == "getPictures" {
+            scannerOptions = CunningScannerOptions.fromArguments(args: call.arguments)
             let presentedVC: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
             self.resultChannel = result
             if VNDocumentCameraViewController.isSupported {
@@ -47,8 +49,16 @@ public class SwiftCunningDocumentScannerPlugin: NSObject, FlutterPlugin, VNDocum
         var filenames: [String] = []
         for i in 0 ..< scan.pageCount {
             let page = scan.imageOfPage(at: i)
-            let url = tempDirPath.appendingPathComponent(formattedDate + "-\(i).png")
-            try? page.pngData()?.write(to: url)
+            let url = tempDirPath.appendingPathComponent(formattedDate + "-\(i).\(scannerOptions.imageFormat.rawValue)")
+            switch scannerOptions.imageFormat {
+            case CunningScannerImageFormat.jpg:
+                try? page.jpegData(compressionQuality: scannerOptions.jpgCompressionQuality)?.write(to: url)
+                break
+            case CunningScannerImageFormat.png:
+                try? page.pngData()?.write(to: url)
+                break
+            }
+            
             filenames.append(url.path)
         }
         resultChannel?(filenames)

--- a/lib/cunning_document_scanner.dart
+++ b/lib/cunning_document_scanner.dart
@@ -3,13 +3,20 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import 'ios_options.dart';
+
+export 'ios_options.dart';
+
 class CunningDocumentScanner {
   static const MethodChannel _channel =
       MethodChannel('cunning_document_scanner');
 
   /// Call this to start get Picture workflow.
-  static Future<List<String>?> getPictures(
-      {int noOfPages = 100, bool isGalleryImportAllowed = false}) async {
+  static Future<List<String>?> getPictures({
+    int noOfPages = 100,
+    bool isGalleryImportAllowed = false,
+    IosScannerOptions? iosScannerOptions,
+  }) async {
     Map<Permission, PermissionStatus> statuses = await [
       Permission.camera,
     ].request();
@@ -20,7 +27,12 @@ class CunningDocumentScanner {
 
     final List<dynamic>? pictures = await _channel.invokeMethod('getPictures', {
       'noOfPages': noOfPages,
-      'isGalleryImportAllowed': isGalleryImportAllowed
+      'isGalleryImportAllowed': isGalleryImportAllowed,
+      if (iosScannerOptions != null)
+        'iosScannerOptions': {
+          'imageFormat': iosScannerOptions.imageFormat.name,
+          'jpgCompressionQuality': iosScannerOptions.jpgCompressionQuality,
+        }
     });
     return pictures?.map((e) => e as String).toList();
   }

--- a/lib/ios_options.dart
+++ b/lib/ios_options.dart
@@ -1,0 +1,37 @@
+/// Enumerates the different output image formats are supported.
+enum IosImageFormat {
+  /// Indicates the output image should be formatted as JPEG image.
+  jpg,
+
+  /// Indicates the output image should be formatted as PNG image.
+  png,
+}
+
+/// Different options that modify the behavior of the document scanner on iOS.
+///
+/// The [imageFormat] specifies the format of the output image file. Available
+/// options are [IosImageFormat.jpeg] or [IosImageFormat.png]. Default value is
+/// [IosImageFormat.png].
+///
+/// If [imageFormat] is set to [IosImageFormat.jpeg] the [jpgCompressionQuality]
+/// can be used to control the quality of the resulting JPEG image. The value
+/// 0.0 represents the maximum compression (or lowest quality) while the value
+/// 1.0 represents the least compression (or best quality). Default value is 1.0.
+final class IosScannerOptions {
+  /// Creates a [IosScannerOptions].
+  const IosScannerOptions({
+    this.imageFormat = IosImageFormat.png,
+    this.jpgCompressionQuality = 1.0,
+  });
+
+  final IosImageFormat imageFormat;
+
+  /// The quality of the resulting JPEG image, expressed as a value from 0.0 to
+  /// 1.0.
+  ///
+  /// The value 0.0 represents the maximum compression (or lowest quality) while
+  /// the value 1.0 represents the least compression (or best quality). The
+  /// [jpgCompressionQuality] only has an effect if the [imageFormat] is set to
+  /// [IosImageFormat.jpeg] and is ignored otherwise.
+  final double jpgCompressionQuality;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cunning_document_scanner
 description: A document scanner plugin for flutter. Scan and crop automatically on iOS and Android.
-version: 1.2.3
+version: 1.3.0
 homepage: https://cunning.biz
 repository: https://github.com/jachzen/cunning_document_scanner
 


### PR DESCRIPTION
First of all thank you for this great plugin, it does an amazing job. 

Based on some feedback from our customers, we discovered that in many cases the scans made on iOS devices resulted in far bigger image files when comparing to scanning the same documents on an Android device. 

Digging through the code base I quickly realized that this is caused be the different image formats used on the different platforms. On Android all scans are save using the JPEG format, while on iOS scans are saved using the PNG format. Comparing a simple A4 document resulted in a 7.5 MB file on on iOS, while on Android the same scan was only 450 KB in file size. 

This PR adds support to supply an instance of the `IosScannerOptions` to the `getPictures` method which allows users to specify which format should be used to save scans on iOS. The parameter is optional and if not specified the plugin behaves exactly as the current version. 

Example usage:

```dart
   // Returns images in PNG format. 
   final imagesPath = await CunningDocumentScanner.getPictures(
      iosScannerOptions: IosScannerOptions(
         imageFormat: IosImageFormat.png,
      ),
   );

   // Returns images in JPEG format with a compression quality of 50%. 
   final imagesPath = await CunningDocumentScanner.getPictures(
      iosScannerOptions: IosScannerOptions(
         imageFormat: IosImageFormat.jpg,
         jpgCompressionQuality: 0.5,
      ),
   );
```